### PR TITLE
Ulcerated Tree Spirit in Millicent Quest

### DIFF
--- a/data/quests.ts
+++ b/data/quests.ts
@@ -347,7 +347,7 @@ export const Quests: Array<ListType> = [
       {
         id: "f2c70662-3c07-4bc6-8408-2f86102709e1",
         description:
-          "Defeat the Rot Worm between the Elphael Inner Wall grace and the Drainage Channnel grace.",
+          "Defeat the Ulcerated Tree Spirit between the Elphael Inner Wall grace and the Drainage Channnel grace.",
       },
       {
         id: "1d01e0d5-6856-418d-85c2-f4cbc8f8f62b",


### PR DESCRIPTION
> Millicent will next be available at the Prayer Room Grace at [Elphael Brace of the Haligtree](https://eldenring.wiki.fextralife.com/Elphael+Brace+of+the+Haligtree). She will not move from this spot until the player has defeated a [Ulcerated Tree Spirit](https://eldenring.wiki.fextralife.com/Ulcerated+Tree+Spirit) mini-boss just before the Drainage Channel Grace.
Once the player has defeated the mini-boss and reloaded the area, there will be two summon signs near where the mini-boss used to be. The player can either:

[https://eldenring.wiki.fextralife.com/Millicent](https://eldenring.wiki.fextralife.com/Millicent)