### PR TITLE
Add Meteorite Staff to Weapons List

### DIFF
--- a/data/lists/weapons.ts
+++ b/data/lists/weapons.ts
@@ -960,6 +960,13 @@ export const WeaponsList: Array<ListType> = [
         ),
       },
       {
+        id: "comment-the-rule-to-gen-this-id",
+        description: rawHTMLLink(
+          "https://eldenring.wiki.fextralife.com/Meteorite+Staff",
+          "Meteorite Staff"
+        ),
+      },
+      {
         id: "104b71e9-1492-400c-8ee1-e0225b0bcc83",
         description: rawHTMLLink(
           "https://eldenring.wiki.fextralife.com/Prince+of+Death's+Staff",

--- a/data/lists/weapons.ts
+++ b/data/lists/weapons.ts
@@ -960,7 +960,7 @@ export const WeaponsList: Array<ListType> = [
         ),
       },
       {
-        id: "comment-the-rule-to-gen-this-id",
+        id: "22b42c39-ca55-494c-8011-90b50344d5f8",
         description: rawHTMLLink(
           "https://eldenring.wiki.fextralife.com/Meteorite+Staff",
           "Meteorite Staff"


### PR DESCRIPTION
The Glintstone Staves Checklist didn't had Meteorite Staff.

## Proposed Solution
@Gobluebro I don't know how this `ID` works, can you help me with it? Or commit it, if you prefer.

```ts
      {
        id: "comment-the-rule-to-gen-this-id",
        description: rawHTMLLink(
          "https://eldenring.wiki.fextralife.com/Meteorite+Staff",
          "Meteorite Staff"
        ),
      },
```