### PR TITLE
Add hash values to maintain tab between page loads

### DIFF
--- a/data/tabs.ts
+++ b/data/tabs.ts
@@ -11,7 +11,6 @@ import {
 } from "./lists";
 
 export enum TabNames {
-  Default,
   Quests,
   Achievements,
   Graces,

--- a/data/tabs.ts
+++ b/data/tabs.ts
@@ -11,6 +11,7 @@ import {
 } from "./lists";
 
 export enum TabNames {
+  Default,
   Quests,
   Achievements,
   Graces,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,15 +15,15 @@ const Home: NextPage = () => {
       return;
 
     // on tab change, update hash
-    window.location.hash = TabNames[currentTab];
+    localStorage.setItem("currentTab", TabNames[currentTab]);
   }, [currentTab]);
 
   useEffect(() => {
     // on page load, check for hash and change tab, if applicable
-    var hashValue = window.location.hash ? window.location.hash.replace('#', '') : '';
-    var selectedTab = hashValue as keyof typeof TabNames;
+    const storedCurrentTab = localStorage.getItem("currentTab");
+    const selectedTab = storedCurrentTab as keyof typeof TabNames;
 
-    if (hashValue && selectedTab in TabNames) { 
+    if (storedCurrentTab && selectedTab in TabNames) { 
       setCurrentTab(TabNames[selectedTab])
     } else {
       setCurrentTab(TabNames.Quests)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,34 @@
 import type { NextPage } from "next";
 import Head from "next/head";
 import CompleteList from "../components/completeList";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import TabBar from "../components/tabBar";
 import Footer from "../components/footer";
 import MetaAndIcons from "../components/metaAndIcons";
 import { TabNames } from "../data/tabs";
 
 const Home: NextPage = () => {
-  const [currentTab, setCurrentTab] = useState<TabNames>(TabNames.Quests);
+  const [currentTab, setCurrentTab] = useState<TabNames>(TabNames.Default);
+    
+  useEffect(() => {
+    if (currentTab == TabNames.Default)
+      return;
+
+    // on tab change, update hash
+    window.location.hash = TabNames[currentTab];
+  }, [currentTab]);
+
+  useEffect(() => {
+    // on page load, check for hash and change tab, if applicable
+    var hashValue = window.location.hash ? window.location.hash.replace('#', '') : '';
+
+    if (hashValue) { 
+      var selectedTab = hashValue as keyof typeof TabNames;
+      setCurrentTab(TabNames[selectedTab])
+    } else {
+      setCurrentTab(TabNames.Quests)
+    }
+  }, []);
 
   return (
     <div className="container flex flex-col min-h-screen mx-auto">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,34 +1,17 @@
 import type { NextPage } from "next";
 import Head from "next/head";
 import CompleteList from "../components/completeList";
-import { useEffect, useState } from "react";
 import TabBar from "../components/tabBar";
 import Footer from "../components/footer";
 import MetaAndIcons from "../components/metaAndIcons";
 import { TabNames } from "../data/tabs";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 
 const Home: NextPage = () => {
-  const [currentTab, setCurrentTab] = useState<TabNames>(TabNames.Default);
-    
-  useEffect(() => {
-    if (currentTab == TabNames.Default)
-      return;
-
-    // on tab change, update hash
-    localStorage.setItem("currentTab", TabNames[currentTab]);
-  }, [currentTab]);
-
-  useEffect(() => {
-    // on page load, check for hash and change tab, if applicable
-    const storedCurrentTab = localStorage.getItem("currentTab");
-    const selectedTab = storedCurrentTab as keyof typeof TabNames;
-
-    if (storedCurrentTab && selectedTab in TabNames) { 
-      setCurrentTab(TabNames[selectedTab])
-    } else {
-      setCurrentTab(TabNames.Quests)
-    }
-  }, []);
+  const [currentTab, setCurrentTab] = useLocalStorage(
+    "currentTab",
+    TabNames.Quests
+  );
 
   return (
     <div className="container flex flex-col min-h-screen mx-auto">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,9 +21,9 @@ const Home: NextPage = () => {
   useEffect(() => {
     // on page load, check for hash and change tab, if applicable
     var hashValue = window.location.hash ? window.location.hash.replace('#', '') : '';
+    var selectedTab = hashValue as keyof typeof TabNames;
 
-    if (hashValue) { 
-      var selectedTab = hashValue as keyof typeof TabNames;
+    if (hashValue && selectedTab in TabNames) { 
       setCurrentTab(TabNames[selectedTab])
     } else {
       setCurrentTab(TabNames.Quests)


### PR DESCRIPTION
Hey @Gobluebro, I thought it would be neat to set hash values in the url to land you on the correct tab each time you hit the site, rather than always defaulting to "Quests." The default remains "Quests" if no hash value is present, or the hash value is a bad value. Seems useful so you don't have to constantly switch tabs anytime you come back to the page (an issue I have frequently with an otherwise great web app!) Thanks!